### PR TITLE
Implement ASE compatibility layer

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,9 +37,7 @@ jobs:
     - name: run tests
       shell: bash -l {0}
       run: |
-        pip install -e .
-        pip install pytest
-        pip install pytest-cov
+        pip install --no-deps --no-build-isolation -e .
         pytest --cov-report=xml --cov=pyscal tests/
 
     - name: Upload coverage to Codecov

--- a/src/pyscal3/ase.py
+++ b/src/pyscal3/ase.py
@@ -13,6 +13,7 @@ from pyscal3.operations.cna import (
     identify_diamond as _identify_diamond,
 )
 from pyscal3.operations.identify import find_neighbors
+from pyscal3.operations.symmetry import get_symmetry as _get_symmetry
 
 
 def _get_structure(ase_atoms: Atoms) -> pc.System:
@@ -68,3 +69,4 @@ calculate_cna = _wrap_function(funct=_calculate_cna, add_find_neighbors=False)
 calculate_diamond_structure = _wrap_function(funct=_identify_diamond, add_find_neighbors=False)
 calculate_radial_distribution_function = _wrap_function(funct=_calculate_rdf, add_find_neighbors=False)
 calculate_steinhardt_parameter = _wrap_function(funct=_calculate_q, add_find_neighbors=True)
+get_symmetry = _wrap_function(funct=_get_symmetry, add_find_neighbors=False)

--- a/src/pyscal3/ase.py
+++ b/src/pyscal3/ase.py
@@ -17,6 +17,22 @@ from pyscal3.operations.identify import find_neighbors
 from pyscal3.operations.symmetry import get_symmetry as _get_symmetry
 
 
+def _get_voronoi_volume(system: pc.System) -> pc.System:
+    """
+    Calculate the Voronoi volume of atoms
+
+    Parameters
+    ----------
+    system: System object
+
+    Returns
+    -------
+        np.ndarray: Array of Voronoi volumes for each atom.
+    """
+    system.find.neighbors(method="voronoi")
+    return system
+
+
 def _get_structure(ase_atoms: Atoms) -> pc.System:
     return pc.System(ase_atoms, format='ase')
 
@@ -109,6 +125,12 @@ calculate_steinhardt_parameter = _wrap_function(
     add_find_neighbors=True,
     return_system=False,
     system_attribute="",
+)
+calculate_voronoi_volume = _wrap_function(
+    funct=_get_voronoi_volume,
+    add_find_neighbors=False,
+    return_system=True,
+    system_attribute="atoms.voronoi.volume",
 )
 get_symmetry = _wrap_function(
     funct=_get_symmetry,

--- a/src/pyscal3/ase.py
+++ b/src/pyscal3/ase.py
@@ -5,7 +5,10 @@ from ase.atoms import Atoms
 import pyscal3.core as pc
 from pyscal3.operations.centrosymmetry import calculate_centrosymmetry as _calculate_centrosymmetry
 from pyscal3.operations.calculations import calculate_q as _calculate_q
-from pyscal3.operations.cna import calculate_cna as _calculate_cna
+from pyscal3.operations.cna import (
+    calculate_cna as _calculate_cna,
+    identify_diamond as _identify_diamond,
+)
 from pyscal3.operations.identify import find_neighbors
 
 
@@ -60,3 +63,4 @@ def _wrap_function(funct: callable, add_find_neighbors: bool = False) -> callabl
 calculate_centrosymmetry = _wrap_function(funct=_calculate_centrosymmetry, add_find_neighbors=False)
 calculate_cna = _wrap_function(funct=_calculate_cna, add_find_neighbors=False)
 calculate_steinhardt_parameter = _wrap_function(funct=_calculate_q, add_find_neighbors=True)
+calculate_diamond_structure = _wrap_function(funct=_identify_diamond, add_find_neighbors=False)

--- a/src/pyscal3/ase.py
+++ b/src/pyscal3/ase.py
@@ -1,45 +1,62 @@
 import inspect
 
-
 from ase.atoms import Atoms
 
 import pyscal3.core as pc
 from pyscal3.operations.centrosymmetry import calculate_centrosymmetry as _calculate_centrosymmetry
+from pyscal3.operations.calculations import calculate_q as _calculate_q
 from pyscal3.operations.cna import calculate_cna as _calculate_cna
+from pyscal3.operations.identify import find_neighbors
 
 
 def _get_structure(ase_atoms: Atoms) -> pc.System:
     return pc.System(ase_atoms, format='ase')
 
 
-def _get_updated_signature(signature: inspect.Signature) -> inspect.Signature:
+def _get_updated_signature(signature: inspect.Signature, add_find_neighbors: bool = False) -> inspect.Signature:
     parameters = signature.parameters.copy()
     del parameters["system"]
-    ase_atoms_parameter = inspect.Parameter(
+    parameters["ase_atoms"] = inspect.Parameter(
         name="ase_atoms",
         kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
         annotation=Atoms,
     )
-    parameters["ase_atoms"] = ase_atoms_parameter
+    if add_find_neighbors:
+        for k, v in inspect.signature(find_neighbors).parameters.items():
+            if k != "system":
+                parameters[k] = v
     parameters.move_to_end("ase_atoms", last = False)
     return signature.replace(parameters=parameters.values())
 
 
-def _wrap_function(input_function: callable) -> callable:
-    sig_updated = _get_updated_signature(signature=inspect.signature(input_function))
+def _wrap_function(funct: callable, add_find_neighbors: bool = False) -> callable:
+    sig_updated = _get_updated_signature(
+        signature=inspect.signature(funct),
+        add_find_neighbors=add_find_neighbors,
+    )
 
     def ase_compatibility_wrapper(*args, **kwargs):
         input_dict = sig_updated.bind(*args, **kwargs).arguments
-        input_dict["system"] = _get_structure(input_dict.pop("ase_atoms"))
-        return input_function(**input_dict)
+        pc_system = _get_structure(input_dict.pop("ase_atoms"))
+        if add_find_neighbors:
+            find_neighbor_keys = inspect.signature(find_neighbors).parameters.keys()
+            find_neighbors_kwargs = {
+                k: input_dict.pop(k)
+                for k in find_neighbor_keys
+                if k != "system" and k in input_dict
+            }
+            pc_system.find.neighbors(**find_neighbors_kwargs)
+        input_dict["system"] = pc_system
+        return funct(**input_dict)
 
-    ase_compatibility_wrapper.__name__ = input_function.__name__
+    ase_compatibility_wrapper.__name__ = funct.__name__
     ase_compatibility_wrapper.__signature__ = sig_updated
-    ase_compatibility_wrapper.__doc__ = input_function.__doc__.replace(
+    ase_compatibility_wrapper.__doc__ = funct.__doc__.replace(
         "system: System object", "ase_atoms: ase.atoms.Atoms object"
     )
     return ase_compatibility_wrapper
 
 
-calculate_centrosymmetry = _wrap_function(_calculate_centrosymmetry)
-calculate_cna = _wrap_function(_calculate_cna)
+calculate_centrosymmetry = _wrap_function(funct=_calculate_centrosymmetry, add_find_neighbors=False)
+calculate_cna = _wrap_function(funct=_calculate_cna, add_find_neighbors=False)
+calculate_steinhardt_parameter = _wrap_function(funct=_calculate_q, add_find_neighbors=True)

--- a/src/pyscal3/ase.py
+++ b/src/pyscal3/ase.py
@@ -4,7 +4,10 @@ from ase.atoms import Atoms
 
 import pyscal3.core as pc
 from pyscal3.operations.centrosymmetry import calculate_centrosymmetry as _calculate_centrosymmetry
-from pyscal3.operations.calculations import calculate_q as _calculate_q
+from pyscal3.operations.calculations import (
+    calculate_q as _calculate_q,
+    calculate_rdf as _calculate_rdf,
+)
 from pyscal3.operations.cna import (
     calculate_cna as _calculate_cna,
     identify_diamond as _identify_diamond,
@@ -62,5 +65,6 @@ def _wrap_function(funct: callable, add_find_neighbors: bool = False) -> callabl
 
 calculate_centrosymmetry = _wrap_function(funct=_calculate_centrosymmetry, add_find_neighbors=False)
 calculate_cna = _wrap_function(funct=_calculate_cna, add_find_neighbors=False)
-calculate_steinhardt_parameter = _wrap_function(funct=_calculate_q, add_find_neighbors=True)
 calculate_diamond_structure = _wrap_function(funct=_identify_diamond, add_find_neighbors=False)
+calculate_radial_distribution_function = _wrap_function(funct=_calculate_rdf, add_find_neighbors=False)
+calculate_steinhardt_parameter = _wrap_function(funct=_calculate_q, add_find_neighbors=True)

--- a/src/pyscal3/ase.py
+++ b/src/pyscal3/ase.py
@@ -1,0 +1,45 @@
+import inspect
+
+
+from ase.atoms import Atoms
+
+import pyscal3.core as pc
+from pyscal3.operations.centrosymmetry import calculate_centrosymmetry as _calculate_centrosymmetry
+from pyscal3.operations.cna import calculate_cna as _calculate_cna
+
+
+def _get_structure(ase_atoms: Atoms) -> pc.System:
+    return pc.System(ase_atoms, format='ase')
+
+
+def _get_updated_signature(signature: inspect.Signature) -> inspect.Signature:
+    parameters = signature.parameters.copy()
+    del parameters["system"]
+    ase_atoms_parameter = inspect.Parameter(
+        name="ase_atoms",
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=Atoms,
+    )
+    parameters["ase_atoms"] = ase_atoms_parameter
+    parameters.move_to_end("ase_atoms", last = False)
+    return signature.replace(parameters=parameters.values())
+
+
+def _wrap_function(input_function: callable) -> callable:
+    sig_updated = _get_updated_signature(signature=inspect.signature(input_function))
+
+    def ase_compatibility_wrapper(*args, **kwargs):
+        input_dict = sig_updated.bind(*args, **kwargs).arguments
+        input_dict["system"] = _get_structure(input_dict.pop("ase_atoms"))
+        return input_function(**input_dict)
+
+    ase_compatibility_wrapper.__name__ = input_function.__name__
+    ase_compatibility_wrapper.__signature__ = sig_updated
+    ase_compatibility_wrapper.__doc__ = input_function.__doc__.replace(
+        "system: System object", "ase_atoms: ase.atoms.Atoms object"
+    )
+    return ase_compatibility_wrapper
+
+
+calculate_centrosymmetry = _wrap_function(_calculate_centrosymmetry)
+calculate_cna = _wrap_function(_calculate_cna)

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -88,3 +88,9 @@ def test_calculate_chiparams():
     chi_params = psa.calculate_chiparams(w_bcc, method='cutoff', cutoff=0)
     chip2 = [3, 0, 0, 0, 36, 12, 0, 36, 0]
     assert np.sum(np.array(chi_params)-np.array(chip2)) == 0
+
+
+def test_calculate_voronoi_volume():
+    w_bcc = bulk("W", a=4, cubic=True).repeat([3, 3, 3])
+    voronoi_volume_lst = psa.calculate_voronoi_volume(w_bcc)
+    assert all(np.isclose(voronoi_volume_lst, 32))

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -2,19 +2,13 @@ import pytest
 import os,sys,inspect
 import numpy as np
 import pyscal3.core as pc
-from pyscal3.ase import (
-    calculate_centrosymmetry,
-    calculate_cna,
-    calculate_diamond_structure,
-    calculate_radial_distribution_function,
-    calculate_steinhardt_parameter,
-)
+import pyscal3.ase as psa
 from ase.build import bulk
 
 
 def test_calculate_centrosymmetry():
     ti_hcp = bulk("Ti", orthorhombic=True)
-    q = calculate_centrosymmetry(ti_hcp, nmax=12)
+    q = psa.calculate_centrosymmetry(ti_hcp, nmax=12)
     assert np.round(np.mean(np.array(q)), decimals=2) == 8.7
 
 
@@ -23,19 +17,19 @@ def test_calculate_cna():
     fe_bcc = bulk("Fe")
     ti_hcp = bulk("Ti")
 
-    cna = calculate_cna(al_fcc)
+    cna = psa.calculate_cna(al_fcc)
     assert cna["fcc"] == 1
 
-    cna = calculate_cna(fe_bcc)
+    cna = psa.calculate_cna(fe_bcc)
     assert cna["bcc"] == 1
 
-    cna = calculate_cna(ti_hcp)
+    cna = psa.calculate_cna(ti_hcp)
     assert cna["hcp"] == 2
 
 
 def test_calculate_steinhardt_parameter():
     w_bcc = bulk("W", a=1.0, cubic=True).repeat([4, 4, 4])
-    q = calculate_steinhardt_parameter(
+    q = psa.calculate_steinhardt_parameter(
         ase_atoms=w_bcc,
         q=[4, 6],
         nmax=12,
@@ -46,7 +40,7 @@ def test_calculate_steinhardt_parameter():
     assert np.round(np.mean(np.array(q[1])), decimals=2) == 0.63, "Calculated q4 value is wrong!"
 
     w_bcc = bulk("W", a=1.0, cubic=True).repeat([4, 4, 4])
-    q = calculate_steinhardt_parameter(
+    q = psa.calculate_steinhardt_parameter(
         ase_atoms=w_bcc,
         q=[4, 6],
         nmax=12,
@@ -65,7 +59,7 @@ def test_calculate_diamond_structure():
         repetitions=(2,2,2),
         lattice_constant=4.00,
     ).convert_to.ase()
-    diamond_dict = calculate_diamond_structure(c_diamond)
+    diamond_dict = psa.calculate_diamond_structure(c_diamond)
     assert diamond_dict['cubic diamond'] == len(c_diamond)
 
 
@@ -73,10 +67,10 @@ def test_calculate_radial_distribution_function():
     w_bcc = bulk("W", a=1.00).repeat([10, 10, 10])
     al_fcc = bulk("Al", a=1.00).repeat([10, 10, 10])
 
-    rdf, r = calculate_radial_distribution_function(w_bcc, rmax=2)
+    rdf, r = psa.calculate_radial_distribution_function(w_bcc, rmax=2)
     args = np.argsort(rdf)[::-1]
     assert(r[args[0]] - 0.86 < 1E-5)
 
-    rdf, r = calculate_radial_distribution_function(al_fcc, rmax=2)
+    rdf, r = psa.calculate_radial_distribution_function(al_fcc, rmax=2)
     args = np.argsort(rdf)[::-1]
     assert(r[args[0]] - 0.70 < 1E-5)

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -1,7 +1,7 @@
 import pytest
 import os,sys,inspect
 import numpy as np
-from pyscal3.ase import calculate_centrosymmetry, calculate_cna
+from pyscal3.ase import calculate_centrosymmetry, calculate_cna, calculate_steinhardt_parameter
 from ase.build import bulk
 
 
@@ -24,3 +24,28 @@ def test_calculate_cna():
 
     cna = calculate_cna(ti_hcp)
     assert cna["hcp"] == 2
+
+
+def test_calculate_steinhardt_parameter():
+    w_bcc = bulk("W", a=1.0, cubic=True).repeat([4, 4, 4])
+    q = calculate_steinhardt_parameter(
+        ase_atoms=w_bcc,
+        q=[4, 6],
+        nmax=12,
+        method='cutoff',
+        cutoff=0.9,
+    )
+    assert np.round(np.mean(np.array(q[0])), decimals=2) == 0.51, "Calculated q4 value is wrong!"
+    assert np.round(np.mean(np.array(q[1])), decimals=2) == 0.63, "Calculated q4 value is wrong!"
+
+    w_bcc = bulk("W", a=1.0, cubic=True).repeat([4, 4, 4])
+    q = calculate_steinhardt_parameter(
+        ase_atoms=w_bcc,
+        q=[4, 6],
+        nmax=12,
+        method='cutoff',
+        cutoff=0.9,
+        averaged=True,
+    )
+    assert np.round(np.mean(np.array(q[0])), decimals=2) == 0.51, "Calculated q4 value is wrong!"
+    assert np.round(np.mean(np.array(q[1])), decimals=2) == 0.63, "Calculated q4 value is wrong!"

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -1,7 +1,13 @@
 import pytest
 import os,sys,inspect
 import numpy as np
-from pyscal3.ase import calculate_centrosymmetry, calculate_cna, calculate_steinhardt_parameter
+import pyscal3.core as pc
+from pyscal3.ase import (
+    calculate_centrosymmetry,
+    calculate_cna,
+    calculate_diamond_structure,
+    calculate_steinhardt_parameter,
+)
 from ase.build import bulk
 
 
@@ -49,3 +55,14 @@ def test_calculate_steinhardt_parameter():
     )
     assert np.round(np.mean(np.array(q[0])), decimals=2) == 0.51, "Calculated q4 value is wrong!"
     assert np.round(np.mean(np.array(q[1])), decimals=2) == 0.63, "Calculated q4 value is wrong!"
+
+
+def test_calculate_diamond_structure():
+    # the ASE diamond structure is wrong so we use pyscal to generate the structure
+    c_diamond = pc.System.create.lattice.diamond(
+        element="C",
+        repetitions=(2,2,2),
+        lattice_constant=4.00,
+    ).convert_to.ase()
+    diamond_dict = calculate_diamond_structure(c_diamond)
+    assert diamond_dict['cubic diamond'] == len(c_diamond)

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -1,0 +1,26 @@
+import pytest
+import os,sys,inspect
+import numpy as np
+from pyscal3.ase import calculate_centrosymmetry, calculate_cna
+from ase.build import bulk
+
+
+def test_calculate_centrosymmetry():
+    ti_hcp = bulk("Ti", orthorhombic=True)
+    q = calculate_centrosymmetry(ti_hcp, nmax=12)
+    assert np.round(np.mean(np.array(q)), decimals=2) == 8.7
+
+
+def test_calculate_cna():
+    al_fcc = bulk("Al")
+    fe_bcc = bulk("Fe")
+    ti_hcp = bulk("Ti")
+
+    cna = calculate_cna(al_fcc)
+    assert cna["fcc"] == 1
+
+    cna = calculate_cna(fe_bcc)
+    assert cna["bcc"] == 1
+
+    cna = calculate_cna(ti_hcp)
+    assert cna["hcp"] == 2

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -74,3 +74,10 @@ def test_calculate_radial_distribution_function():
     rdf, r = psa.calculate_radial_distribution_function(al_fcc, rmax=2)
     args = np.argsort(rdf)[::-1]
     assert(r[args[0]] - 0.70 < 1E-5)
+
+
+def test_get_symmetry():
+    w_bcc = bulk("W", cubic=True)
+    al_fcc = bulk("Al", cubic=True)
+    assert psa.get_symmetry(w_bcc)["international_symbol"] == "Im-3m"
+    assert psa.get_symmetry(al_fcc)["international_symbol"] == "Fm-3m"

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -6,6 +6,7 @@ from pyscal3.ase import (
     calculate_centrosymmetry,
     calculate_cna,
     calculate_diamond_structure,
+    calculate_radial_distribution_function,
     calculate_steinhardt_parameter,
 )
 from ase.build import bulk
@@ -66,3 +67,16 @@ def test_calculate_diamond_structure():
     ).convert_to.ase()
     diamond_dict = calculate_diamond_structure(c_diamond)
     assert diamond_dict['cubic diamond'] == len(c_diamond)
+
+
+def test_calculate_radial_distribution_function():
+    w_bcc = bulk("W", a=1.00).repeat([10, 10, 10])
+    al_fcc = bulk("Al", a=1.00).repeat([10, 10, 10])
+
+    rdf, r = calculate_radial_distribution_function(w_bcc, rmax=2)
+    args = np.argsort(rdf)[::-1]
+    assert(r[args[0]] - 0.86 < 1E-5)
+
+    rdf, r = calculate_radial_distribution_function(al_fcc, rmax=2)
+    args = np.argsort(rdf)[::-1]
+    assert(r[args[0]] - 0.70 < 1E-5)

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -81,3 +81,10 @@ def test_get_symmetry():
     al_fcc = bulk("Al", cubic=True)
     assert psa.get_symmetry(w_bcc)["international_symbol"] == "Im-3m"
     assert psa.get_symmetry(al_fcc)["international_symbol"] == "Fm-3m"
+
+
+def test_calculate_chiparams():
+    w_bcc = bulk("W", a=4, cubic=True).repeat([3, 3, 3])
+    chi_params = psa.calculate_chiparams(w_bcc, method='cutoff', cutoff=0)
+    chip2 = [3, 0, 0, 0, 36, 12, 0, 36, 0]
+    assert np.sum(np.array(chi_params)-np.array(chip2)) == 0


### PR DESCRIPTION
To simplify the usage of pyscal for users of the Atomic Simulation Environment (ASE) I propose to dynamically wrap the functions.

Example:
```python
import pyscal3.ase as psa

ti_hcp = bulk("Ti", orthorhombic=True)
q = psa.calculate_centrosymmetry(ti_hcp, nmax=12)
print(q)

al_fcc = bulk("Al")
cna = psa.calculate_cna(al_fcc)
print(cna)
```

Currently `calculate_centrosymmetry()`, `calculate_chiparams()`,`calculate_cna()`, `calculate_diamond_structure()`, `calculate_radial_distribution_function()`, `calculate_steinhardt_parameter()`, `calculate_voronoi_volume()` and `get_symmetry()` are implemented. Still the wrapper is generic and could be extended to support more operations if required. 